### PR TITLE
Fix 8391: use HTTPS proxy when native automation disabled

### DIFF
--- a/src/configuration/testcafe-configuration.ts
+++ b/src/configuration/testcafe-configuration.ts
@@ -2,6 +2,7 @@ import Configuration from './configuration-base';
 import { castArray, flatten } from 'lodash';
 import { getGrepOptions, getSSLOptions } from '../utils/get-options';
 import OPTION_NAMES from './option-names';
+import selfSignedCertificate from 'openssl-self-signed-certificate';
 import getFilterFn from '../utils/get-filter-fn';
 import prepareReporters from '../utils/prepare-reporters';
 import { getConcatenatedValuesString, getPluralSuffix } from '../utils/string';
@@ -152,11 +153,16 @@ export default class TestCafeConfiguration extends Configuration {
     }
 
     public get startOptions (): TestCafeStartOptions {
+        let sslOption: object | undefined = this.getOption(OPTION_NAMES.ssl);
+
+        if (!sslOption && this.getOption(OPTION_NAMES.disableNativeAutomation))
+            sslOption = selfSignedCertificate;
+
         return {
             hostname:           this.getOption(OPTION_NAMES.hostname),
             port1:              this.getOption(OPTION_NAMES.port1),
             port2:              this.getOption(OPTION_NAMES.port2),
-            ssl:                this.getOption(OPTION_NAMES.ssl),
+            ssl:                sslOption,
             developmentMode:    this.getOption(OPTION_NAMES.developmentMode),
             retryTestPages:     this.getOption(OPTION_NAMES.retryTestPages),
             cache:              this.getOption(OPTION_NAMES.cache),

--- a/ts-defs-src/helpers/openssl-self-signed-certificate.d.ts
+++ b/ts-defs-src/helpers/openssl-self-signed-certificate.d.ts
@@ -1,0 +1,4 @@
+declare module 'openssl-self-signed-certificate' {
+    const cert: { key: string | Buffer; cert: string | Buffer };
+    export default cert;
+}


### PR DESCRIPTION
## Summary
- default to self-signed HTTPS when native automation is disabled
- add TS definition for `openssl-self-signed-certificate`

## Testing
- `npx gulp lint`
- `npx gulp test-client-travis` *(fails: Error: exited with error code: 2)*

------
https://chatgpt.com/codex/tasks/task_b_685ec25807748327b2118baf1e4efe40