### PR TITLE
Fix crypto_unavailable error in proxy mode

### DIFF
--- a/@types/openssl-self-signed-certificate/index.d.ts
+++ b/@types/openssl-self-signed-certificate/index.d.ts
@@ -1,0 +1,9 @@
+declare module 'openssl-self-signed-certificate' {
+    interface Certificate {
+        key: Buffer;
+        cert: Buffer;
+    }
+
+    const value: Certificate;
+    export = value;
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+* The `crypto_nonexistent` error no longer occurs in `--disable-native-automation` mode when a page requires a secure context. TestCafe now proxies such pages over HTTPS by default. ([#8391](https://github.com/DevExpress/testcafe/issues/8391))
+
 ## v3.7.2 (2025-02-18)
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-* The `crypto_nonexistent` error no longer occurs in `--disable-native-automation` mode when a page requires a secure context. TestCafe now proxies such pages over HTTPS by default. ([#8391](https://github.com/DevExpress/testcafe/issues/8391))
+* Fixed the `crypto_nonexistent` error that appeared in `--disable-native-automation` mode when a page required a secure context. TestCafe now proxies those pages over HTTPS automatically. ([#8391](https://github.com/DevExpress/testcafe/issues/8391))
 
 ## v3.7.2 (2025-02-18)
 

--- a/src/configuration/testcafe-configuration.ts
+++ b/src/configuration/testcafe-configuration.ts
@@ -197,6 +197,9 @@ export default class TestCafeConfiguration extends Configuration {
     }
 
     private async _normalizeOptionsAfterLoad (): Promise<void> {
+        if (this.getOption(OPTION_NAMES.disableNativeAutomation) && !this._options[OPTION_NAMES.ssl])
+            this._options[OPTION_NAMES.ssl] = { value: selfSignedCertificate, source: OptionSource.Configuration } as any;
+
         await this._prepareSslOptions();
         this._prepareInitFlags();
         this._prepareFilterFn();
@@ -276,9 +279,6 @@ export default class TestCafeConfiguration extends Configuration {
         this._ensureOptionWithValue(OPTION_NAMES.disableNativeAutomation, DEFAULT_DISABLE_NATIVE_AUTOMATION, OptionSource.Configuration);
         this._ensureOptionWithValue(OPTION_NAMES.experimentalMultipleWindows, DEFAULT_EXPERIMENTAL_MULTIPLE_WINDOWS, OptionSource.Configuration);
         this._ensureOptionWithValue(OPTION_NAMES.disableCrossDomain, DEFAULT_DISABLE_CROSS_DOMAIN, OptionSource.Configuration);
-
-        if (this.getOption(OPTION_NAMES.disableNativeAutomation) && !this._options[OPTION_NAMES.ssl])
-            this._options[OPTION_NAMES.ssl] = { value: selfSignedCertificate, source: OptionSource.Configuration } as any;
 
         this._ensureScreenshotOptions();
         this._ensureSkipJsOptions();

--- a/src/configuration/testcafe-configuration.ts
+++ b/src/configuration/testcafe-configuration.ts
@@ -28,6 +28,8 @@ import {
 
 import OptionSource from './option-source';
 
+import selfSignedCertificate from 'openssl-self-signed-certificate';
+
 import {
     Dictionary,
     FilterOption,
@@ -274,6 +276,9 @@ export default class TestCafeConfiguration extends Configuration {
         this._ensureOptionWithValue(OPTION_NAMES.disableNativeAutomation, DEFAULT_DISABLE_NATIVE_AUTOMATION, OptionSource.Configuration);
         this._ensureOptionWithValue(OPTION_NAMES.experimentalMultipleWindows, DEFAULT_EXPERIMENTAL_MULTIPLE_WINDOWS, OptionSource.Configuration);
         this._ensureOptionWithValue(OPTION_NAMES.disableCrossDomain, DEFAULT_DISABLE_CROSS_DOMAIN, OptionSource.Configuration);
+
+        if (this.getOption(OPTION_NAMES.disableNativeAutomation) && !this._options[OPTION_NAMES.ssl])
+            this._options[OPTION_NAMES.ssl] = { value: selfSignedCertificate, source: OptionSource.Configuration } as any;
 
         this._ensureScreenshotOptions();
         this._ensureSkipJsOptions();

--- a/src/configuration/testcafe-configuration.ts
+++ b/src/configuration/testcafe-configuration.ts
@@ -198,7 +198,7 @@ export default class TestCafeConfiguration extends Configuration {
 
     private async _normalizeOptionsAfterLoad (): Promise<void> {
         if (this.getOption(OPTION_NAMES.disableNativeAutomation) && !this._options[OPTION_NAMES.ssl])
-            this._options[OPTION_NAMES.ssl] = { value: selfSignedCertificate, source: OptionSource.Configuration } as any;
+            this._options[OPTION_NAMES.ssl] = { value: selfSignedCertificate(), source: OptionSource.Configuration } as any;
 
         await this._prepareSslOptions();
         this._prepareInitFlags();


### PR DESCRIPTION
## Summary
- proxy pages over HTTPS when native automation is disabled
- add type defs for openssl-self-signed-certificate
- document fix

## Testing
- `npm run build` *(fails: server-scripts-compile error)*

------
https://chatgpt.com/codex/tasks/task_b_685ec25807748327b2118baf1e4efe40