### PR TITLE
Fix crypto_unavailable error in proxy mode

### DIFF
--- a/@types/openssl-self-signed-certificate/index.d.ts
+++ b/@types/openssl-self-signed-certificate/index.d.ts
@@ -1,0 +1,9 @@
+declare module 'openssl-self-signed-certificate' {
+    interface Certificate {
+        key: Buffer;
+        cert: Buffer;
+    }
+
+    const value: Certificate;
+    export = value;
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+* The `crypto_nonexistent` error no longer occurs in `--disable-native-automation` mode when a page requires a secure context. TestCafe now proxies such pages over HTTPS by default. ([#8391](https://github.com/DevExpress/testcafe/issues/8391))
+
 ## v3.7.2 (2025-02-18)
 
 ### Bug Fixes

--- a/src/configuration/testcafe-configuration.ts
+++ b/src/configuration/testcafe-configuration.ts
@@ -28,6 +28,8 @@ import {
 
 import OptionSource from './option-source';
 
+import selfSignedCertificate from 'openssl-self-signed-certificate';
+
 import {
     Dictionary,
     FilterOption,
@@ -257,7 +259,8 @@ export default class TestCafeConfiguration extends Configuration {
         if (!sslOptions)
             return;
 
-        sslOptions.value = await getSSLOptions(sslOptions.value as string) as Dictionary<string | boolean | number>;
+        if (typeof sslOptions.value === 'string')
+            sslOptions.value = await getSSLOptions(sslOptions.value as string) as Dictionary<string | boolean | number>;
     }
 
     private _setDefaultValues (): void {
@@ -274,6 +277,9 @@ export default class TestCafeConfiguration extends Configuration {
         this._ensureOptionWithValue(OPTION_NAMES.disableNativeAutomation, DEFAULT_DISABLE_NATIVE_AUTOMATION, OptionSource.Configuration);
         this._ensureOptionWithValue(OPTION_NAMES.experimentalMultipleWindows, DEFAULT_EXPERIMENTAL_MULTIPLE_WINDOWS, OptionSource.Configuration);
         this._ensureOptionWithValue(OPTION_NAMES.disableCrossDomain, DEFAULT_DISABLE_CROSS_DOMAIN, OptionSource.Configuration);
+
+        if (this.getOption(OPTION_NAMES.disableNativeAutomation) && !this._options[OPTION_NAMES.ssl])
+            this._options[OPTION_NAMES.ssl] = { value: selfSignedCertificate, source: OptionSource.Configuration } as any;
 
         this._ensureScreenshotOptions();
         this._ensureSkipJsOptions();

--- a/test/server/create-testcafe-test.js
+++ b/test/server/create-testcafe-test.js
@@ -131,6 +131,19 @@ describe('TestCafe factory function', function () {
             });
     });
 
+    it('Should enable HTTPS when native automation is disabled', async () => {
+        await createTestCafe({
+            hostname:                'localhost',
+            port1:                   1338,
+            port2:                   1339,
+            disableNativeAutomation: true,
+        }).then(tc => {
+            testCafe = tc;
+        });
+
+        expect(testCafe.configuration.startOptions.ssl).eql(selfSignedCertificate);
+    });
+
     describe('Custom Testcafe Config Path', () => {
         it('Reverts back to default when not specified', () => {
             const defaultConfigJSONFile = '.testcaferc.json';


### PR DESCRIPTION
## Summary
- proxy pages over HTTPS when native automation is disabled
- add type defs for openssl-self-signed-certificate
- document fix
- handle default SSL object without re-parsing
- add regression test for auto HTTPS

## Testing
- `npm run build`
- `npm test` *(fails: The following tasks did not complete: travis)*

------
https://chatgpt.com/codex/tasks/task_b_685ec25807748327b2118baf1e4efe40